### PR TITLE
[FreshEyes] Add support for Taproot and `tr()` descriptors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add traits to reuse `Blockchain`s across multiple wallets (`BlockchainFactory` and `StatelessBlockchain`).
 - Upgrade to rust-bitcoin `0.28`
 - If using the `sqlite-db` feature all cached wallet data is deleted due to a possible UTXO inconsistency, a wallet.sync will recreate it  
+- Update `PkOrF` in the policy module to become an enum
 
 ## [v0.18.0] - [v0.17.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade to rust-bitcoin `0.28`
 - If using the `sqlite-db` feature all cached wallet data is deleted due to a possible UTXO inconsistency, a wallet.sync will recreate it  
 - Update `PkOrF` in the policy module to become an enum
+- Add experimental support for Taproot, including:
+  - Support for `tr()` descriptors with complex tapscript trees
+  - Creation of Taproot PSBTs (BIP-371)
+  - Signing Taproot PSBTs (key spend and script spend)
+  - Support for `tr()` descriptors in the `descriptor!()` macro
 
 ## [v0.18.0] - [v0.17.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 bdk-macros = "^0.6"
 log = "^0.4"
 miniscript = { version = "7.0", features = ["use-serde"] }
-bitcoin = { version = "0.28", features = ["use-serde", "base64"] }
+bitcoin = { version = "0.28", features = ["use-serde", "base64", "rand"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 rand = "^0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 bdk-macros = "^0.6"
 log = "^0.4"
 miniscript = { version = "7.0", features = ["use-serde"] }
-bitcoin = { version = "0.28", features = ["use-serde", "base64", "rand"] }
+bitcoin = { version = "0.28.1", features = ["use-serde", "base64", "rand"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 rand = "^0.7"

--- a/src/descriptor/dsl.rs
+++ b/src/descriptor/dsl.rs
@@ -75,6 +75,38 @@ macro_rules! impl_top_level_pk {
 
 #[doc(hidden)]
 #[macro_export]
+macro_rules! impl_top_level_tr {
+    ( $internal_key:expr, $tap_tree:expr ) => {{
+        use $crate::miniscript::descriptor::{Descriptor, DescriptorPublicKey, Tr};
+        use $crate::miniscript::Tap;
+
+        #[allow(unused_imports)]
+        use $crate::keys::{DescriptorKey, IntoDescriptorKey};
+        let secp = $crate::bitcoin::secp256k1::Secp256k1::new();
+
+        $internal_key
+            .into_descriptor_key()
+            .and_then(|key: DescriptorKey<Tap>| key.extract(&secp))
+            .map_err($crate::descriptor::DescriptorError::Key)
+            .and_then(|(pk, mut key_map, mut valid_networks)| {
+                let tap_tree = $tap_tree.map(|(tap_tree, tree_keymap, tree_networks)| {
+                    key_map.extend(tree_keymap.into_iter());
+                    valid_networks = $crate::keys::merge_networks(&valid_networks, &tree_networks);
+
+                    tap_tree
+                });
+
+                Ok((
+                    Descriptor::<DescriptorPublicKey>::Tr(Tr::new(pk, tap_tree)?),
+                    key_map,
+                    valid_networks,
+                ))
+            })
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export]
 macro_rules! impl_leaf_opcode {
     ( $terminal_variant:ident ) => {{
         use $crate::descriptor::CheckMiniscript;
@@ -226,6 +258,62 @@ macro_rules! impl_sortedmulti {
             .and_then(|keys| $crate::keys::make_sortedmulti($thresh, keys, $build_desc, &secp))
     });
 
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! parse_tap_tree {
+    ( @merge $tree_a:expr, $tree_b:expr) => {{
+        use std::sync::Arc;
+        use $crate::miniscript::descriptor::TapTree;
+
+        $tree_a
+            .and_then(|tree_a| Ok((tree_a, $tree_b?)))
+            .and_then(|((a_tree, mut a_keymap, a_networks), (b_tree, b_keymap, b_networks))| {
+                a_keymap.extend(b_keymap.into_iter());
+                Ok((TapTree::Tree(Arc::new(a_tree), Arc::new(b_tree)), a_keymap, $crate::keys::merge_networks(&a_networks, &b_networks)))
+            })
+
+    }};
+
+    // Two sub-trees
+    ( { { $( $tree_a:tt )* }, { $( $tree_b:tt )* } } ) => {{
+        let tree_a = $crate::parse_tap_tree!( { $( $tree_a )* } );
+        let tree_b = $crate::parse_tap_tree!( { $( $tree_b )* } );
+
+        $crate::parse_tap_tree!(@merge tree_a, tree_b)
+    }};
+
+    // One leaf and a sub-tree
+    ( { $op_a:ident ( $( $minisc_a:tt )* ), { $( $tree_b:tt )* } } ) => {{
+        let tree_a = $crate::parse_tap_tree!( $op_a ( $( $minisc_a )* ) );
+        let tree_b = $crate::parse_tap_tree!( { $( $tree_b )* } );
+
+        $crate::parse_tap_tree!(@merge tree_a, tree_b)
+    }};
+    ( { { $( $tree_a:tt )* }, $op_b:ident ( $( $minisc_b:tt )* ) } ) => {{
+        let tree_a = $crate::parse_tap_tree!( { $( $tree_a )* } );
+        let tree_b = $crate::parse_tap_tree!( $op_b ( $( $minisc_b )* ) );
+
+        $crate::parse_tap_tree!(@merge tree_a, tree_b)
+    }};
+
+    // Two leaves
+    ( { $op_a:ident ( $( $minisc_a:tt )* ), $op_b:ident ( $( $minisc_b:tt )* ) } ) => {{
+        let tree_a = $crate::parse_tap_tree!( $op_a ( $( $minisc_a )* ) );
+        let tree_b = $crate::parse_tap_tree!( $op_b ( $( $minisc_b )* ) );
+
+        $crate::parse_tap_tree!(@merge tree_a, tree_b)
+    }};
+
+    // Single leaf
+    ( $op:ident ( $( $minisc:tt )* ) ) => {{
+        use std::sync::Arc;
+        use $crate::miniscript::descriptor::TapTree;
+
+        $crate::fragment!( $op ( $( $minisc )* ) )
+            .map(|(a_minisc, a_keymap, a_networks)| (TapTree::Leaf(Arc::new(a_minisc)), a_keymap, a_networks))
+    }};
 }
 
 #[doc(hidden)]
@@ -440,6 +528,15 @@ macro_rules! descriptor {
     });
     ( wsh ( $( $minisc:tt )* ) ) => ({
         $crate::impl_top_level_sh!(Wsh, new, new_sortedmulti, Segwitv0, $( $minisc )*)
+    });
+
+    ( tr ( $internal_key:expr ) ) => ({
+        $crate::impl_top_level_tr!($internal_key, None)
+    });
+    ( tr ( $internal_key:expr, $( $taptree:tt )* ) ) => ({
+        let tap_tree = $crate::parse_tap_tree!( $( $taptree )* );
+        tap_tree
+            .and_then(|tap_tree| $crate::impl_top_level_tr!($internal_key, Some(tap_tree)))
     });
 }
 

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -14,15 +14,15 @@
 //! This module contains generic utilities to work with descriptors, plus some re-exported types
 //! from [`miniscript`].
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use std::ops::Deref;
 
-use bitcoin::secp256k1;
 use bitcoin::util::bip32::{ChildNumber, DerivationPath, ExtendedPubKey, Fingerprint, KeySource};
 use bitcoin::util::{psbt, taproot};
+use bitcoin::{secp256k1, PublicKey, XOnlyPublicKey};
 use bitcoin::{Network, Script, TxOut};
 
-use miniscript::descriptor::{DescriptorType, InnerXKey};
+use miniscript::descriptor::{DescriptorType, InnerXKey, SinglePubKey};
 pub use miniscript::{
     descriptor::DescriptorXKey, descriptor::KeyMap, descriptor::Wildcard, Descriptor,
     DescriptorPublicKey, Legacy, Miniscript, ScriptContext, Segwitv0,
@@ -322,6 +322,16 @@ pub(crate) trait DescriptorMeta {
         hd_keypaths: &HdKeyPaths,
         secp: &'s SecpCtx,
     ) -> Option<DerivedDescriptor<'s>>;
+    fn derive_from_tap_key_origins<'s>(
+        &self,
+        tap_key_origins: &TapKeyOrigins,
+        secp: &'s SecpCtx,
+    ) -> Option<DerivedDescriptor<'s>>;
+    fn derive_from_psbt_key_origins<'s>(
+        &self,
+        key_origins: BTreeMap<Fingerprint, (&DerivationPath, SinglePubKey)>,
+        secp: &'s SecpCtx,
+    ) -> Option<DerivedDescriptor<'s>>;
     fn derive_from_psbt_input<'s>(
         &self,
         psbt_input: &psbt::Input,
@@ -401,59 +411,122 @@ impl DescriptorMeta for ExtendedDescriptor {
         Ok(answer)
     }
 
-    fn derive_from_hd_keypaths<'s>(
+    fn derive_from_psbt_key_origins<'s>(
         &self,
-        hd_keypaths: &HdKeyPaths,
+        key_origins: BTreeMap<Fingerprint, (&DerivationPath, SinglePubKey)>,
         secp: &'s SecpCtx,
     ) -> Option<DerivedDescriptor<'s>> {
-        let index: HashMap<_, _> = hd_keypaths.values().map(|(a, b)| (a, b)).collect();
+        // Ensure that deriving `xpub` with `path` yields `expected`
+        let verify_key = |xpub: &DescriptorXKey<ExtendedPubKey>,
+                          path: &DerivationPath,
+                          expected: &SinglePubKey| {
+            let derived = xpub
+                .xkey
+                .derive_pub(secp, path)
+                .expect("The path should never contain hardened derivation steps")
+                .public_key;
+
+            match expected {
+                SinglePubKey::FullKey(pk) if &PublicKey::new(derived) == pk => true,
+                SinglePubKey::XOnly(pk) if &XOnlyPublicKey::from(derived) == pk => true,
+                _ => false,
+            }
+        };
 
         let mut path_found = None;
-        self.for_each_key(|key| {
-            if path_found.is_some() {
-                // already found a matching path, we are done
-                return true;
-            }
 
+        // using `for_any_key` should make this stop as soon as we return `true`
+        self.for_any_key(|key| {
             if let DescriptorPublicKey::XPub(xpub) = key.as_key().deref() {
-                // Check if the key matches one entry in our `index`. If it does, `matches()` will
+                // Check if the key matches one entry in our `key_origins`. If it does, `matches()` will
                 // return the "prefix" that matched, so we remove that prefix from the full path
-                // found in `index` and save it in `derive_path`. We expect this to be a derivation
+                // found in `key_origins` and save it in `derive_path`. We expect this to be a derivation
                 // path of length 1 if the key is `wildcard` and an empty path otherwise.
                 let root_fingerprint = xpub.root_fingerprint(secp);
-                let derivation_path: Option<Vec<ChildNumber>> = index
+                let derive_path = key_origins
                     .get_key_value(&root_fingerprint)
-                    .and_then(|(fingerprint, path)| {
-                        xpub.matches(&(**fingerprint, (*path).clone()), secp)
+                    .and_then(|(fingerprint, (path, expected))| {
+                        xpub.matches(&(*fingerprint, (*path).clone()), secp)
+                            .zip(Some((path, expected)))
                     })
-                    .map(|prefix| {
-                        index
-                            .get(&xpub.root_fingerprint(secp))
-                            .unwrap()
+                    .and_then(|(prefix, (full_path, expected))| {
+                        let derive_path = full_path
                             .into_iter()
                             .skip(prefix.into_iter().count())
                             .cloned()
-                            .collect()
+                            .collect::<DerivationPath>();
+
+                        // `derive_path` only contains the replacement index for the wildcard, if present, or
+                        // an empty path for fixed descriptors. To verify the key we also need the normal steps
+                        // that come before the wildcard, so we take them directly from `xpub` and then append
+                        // the final index
+                        if verify_key(
+                            xpub,
+                            &xpub.derivation_path.extend(derive_path.clone()),
+                            expected,
+                        ) {
+                            Some(derive_path)
+                        } else {
+                            log::debug!(
+                                "Key `{}` derived with {} yields an unexpected key",
+                                root_fingerprint,
+                                derive_path
+                            );
+                            None
+                        }
                     });
 
-                match derivation_path {
+                match derive_path {
                     Some(path) if xpub.wildcard != Wildcard::None && path.len() == 1 => {
                         // Ignore hardened wildcards
                         if let ChildNumber::Normal { index } = path[0] {
-                            path_found = Some(index)
+                            path_found = Some(index);
+                            return true;
                         }
                     }
                     Some(path) if xpub.wildcard == Wildcard::None && path.is_empty() => {
-                        path_found = Some(0)
+                        path_found = Some(0);
+                        return true;
                     }
                     _ => {}
                 }
             }
 
-            true
+            false
         });
 
         path_found.map(|path| self.as_derived(path, secp))
+    }
+
+    fn derive_from_hd_keypaths<'s>(
+        &self,
+        hd_keypaths: &HdKeyPaths,
+        secp: &'s SecpCtx,
+    ) -> Option<DerivedDescriptor<'s>> {
+        // "Convert" an hd_keypaths map to the format required by `derive_from_psbt_key_origins`
+        let key_origins = hd_keypaths
+            .iter()
+            .map(|(pk, (fingerprint, path))| {
+                (
+                    *fingerprint,
+                    (path, SinglePubKey::FullKey(PublicKey::new(*pk))),
+                )
+            })
+            .collect();
+        self.derive_from_psbt_key_origins(key_origins, secp)
+    }
+
+    fn derive_from_tap_key_origins<'s>(
+        &self,
+        tap_key_origins: &TapKeyOrigins,
+        secp: &'s SecpCtx,
+    ) -> Option<DerivedDescriptor<'s>> {
+        // "Convert" a tap_key_origins map to the format required by `derive_from_psbt_key_origins`
+        let key_origins = tap_key_origins
+            .iter()
+            .map(|(pk, (_, (fingerprint, path)))| (*fingerprint, (path, SinglePubKey::XOnly(*pk))))
+            .collect();
+        self.derive_from_psbt_key_origins(key_origins, secp)
     }
 
     fn derive_from_psbt_input<'s>(
@@ -463,6 +536,9 @@ impl DescriptorMeta for ExtendedDescriptor {
         secp: &'s SecpCtx,
     ) -> Option<DerivedDescriptor<'s>> {
         if let Some(derived) = self.derive_from_hd_keypaths(&psbt_input.bip32_derivation, secp) {
+            return Some(derived);
+        }
+        if let Some(derived) = self.derive_from_tap_key_origins(&psbt_input.tap_key_origins, secp) {
             return Some(derived);
         }
         if self.is_deriveable() {

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -21,6 +21,7 @@
 //! ```
 //! # use std::sync::Arc;
 //! # use bdk::descriptor::*;
+//! # use bdk::wallet::signer::*;
 //! # use bdk::bitcoin::secp256k1::Secp256k1;
 //! use bdk::descriptor::policy::BuildSatisfaction;
 //! let secp = Secp256k1::new();
@@ -29,7 +30,7 @@
 //! let (extended_desc, key_map) = ExtendedDescriptor::parse_descriptor(&secp, desc)?;
 //! println!("{:?}", extended_desc);
 //!
-//! let signers = Arc::new(key_map.into());
+//! let signers = Arc::new(SignersContainer::build(key_map, &extended_desc, &secp));
 //! let policy = extended_desc.extract_policy(&signers, BuildSatisfaction::None, &secp)?;
 //! println!("policy: {}", serde_json::to_string(&policy)?);
 //! # Ok::<(), bdk::Error>(())
@@ -1109,7 +1110,7 @@ mod test {
         let (wallet_desc, keymap) = desc
             .into_wallet_descriptor(&secp, Network::Testnet)
             .unwrap();
-        let signers_container = Arc::new(SignersContainer::from(keymap));
+        let signers_container = Arc::new(SignersContainer::build(keymap, &wallet_desc, &secp));
         let policy = wallet_desc
             .extract_policy(&signers_container, BuildSatisfaction::None, &secp)
             .unwrap()
@@ -1124,7 +1125,7 @@ mod test {
         let (wallet_desc, keymap) = desc
             .into_wallet_descriptor(&secp, Network::Testnet)
             .unwrap();
-        let signers_container = Arc::new(SignersContainer::from(keymap));
+        let signers_container = Arc::new(SignersContainer::build(keymap, &wallet_desc, &secp));
         let policy = wallet_desc
             .extract_policy(&signers_container, BuildSatisfaction::None, &secp)
             .unwrap()
@@ -1148,7 +1149,7 @@ mod test {
         let (wallet_desc, keymap) = desc
             .into_wallet_descriptor(&secp, Network::Testnet)
             .unwrap();
-        let signers_container = Arc::new(SignersContainer::from(keymap));
+        let signers_container = Arc::new(SignersContainer::build(keymap, &wallet_desc, &secp));
         let policy = wallet_desc
             .extract_policy(&signers_container, BuildSatisfaction::None, &secp)
             .unwrap()
@@ -1180,7 +1181,7 @@ mod test {
         let (wallet_desc, keymap) = desc
             .into_wallet_descriptor(&secp, Network::Testnet)
             .unwrap();
-        let signers_container = Arc::new(SignersContainer::from(keymap));
+        let signers_container = Arc::new(SignersContainer::build(keymap, &wallet_desc, &secp));
         let policy = wallet_desc
             .extract_policy(&signers_container, BuildSatisfaction::None, &secp)
             .unwrap()
@@ -1212,7 +1213,7 @@ mod test {
         let (wallet_desc, keymap) = desc
             .into_wallet_descriptor(&secp, Network::Testnet)
             .unwrap();
-        let signers_container = Arc::new(SignersContainer::from(keymap));
+        let signers_container = Arc::new(SignersContainer::build(keymap, &wallet_desc, &secp));
         let policy = wallet_desc
             .extract_policy(&signers_container, BuildSatisfaction::None, &secp)
             .unwrap()
@@ -1244,7 +1245,7 @@ mod test {
         let (wallet_desc, keymap) = desc
             .into_wallet_descriptor(&secp, Network::Testnet)
             .unwrap();
-        let signers_container = Arc::new(SignersContainer::from(keymap));
+        let signers_container = Arc::new(SignersContainer::build(keymap, &wallet_desc, &secp));
         let policy = wallet_desc
             .extract_policy(&signers_container, BuildSatisfaction::None, &secp)
             .unwrap()
@@ -1277,7 +1278,7 @@ mod test {
             .into_wallet_descriptor(&secp, Network::Testnet)
             .unwrap();
         let single_key = wallet_desc.derive(0);
-        let signers_container = Arc::new(SignersContainer::from(keymap));
+        let signers_container = Arc::new(SignersContainer::build(keymap, &wallet_desc, &secp));
         let policy = single_key
             .extract_policy(&signers_container, BuildSatisfaction::None, &secp)
             .unwrap()
@@ -1293,7 +1294,7 @@ mod test {
             .into_wallet_descriptor(&secp, Network::Testnet)
             .unwrap();
         let single_key = wallet_desc.derive(0);
-        let signers_container = Arc::new(SignersContainer::from(keymap));
+        let signers_container = Arc::new(SignersContainer::build(keymap, &wallet_desc, &secp));
         let policy = single_key
             .extract_policy(&signers_container, BuildSatisfaction::None, &secp)
             .unwrap()
@@ -1320,7 +1321,7 @@ mod test {
             .into_wallet_descriptor(&secp, Network::Testnet)
             .unwrap();
         let single_key = wallet_desc.derive(0);
-        let signers_container = Arc::new(SignersContainer::from(keymap));
+        let signers_container = Arc::new(SignersContainer::build(keymap, &wallet_desc, &secp));
         let policy = single_key
             .extract_policy(&signers_container, BuildSatisfaction::None, &secp)
             .unwrap()
@@ -1363,7 +1364,7 @@ mod test {
         let (wallet_desc, keymap) = desc
             .into_wallet_descriptor(&secp, Network::Testnet)
             .unwrap();
-        let signers_container = Arc::new(SignersContainer::from(keymap));
+        let signers_container = Arc::new(SignersContainer::build(keymap, &wallet_desc, &secp));
         let policy = wallet_desc
             .extract_policy(&signers_container, BuildSatisfaction::None, &secp)
             .unwrap()
@@ -1402,7 +1403,7 @@ mod test {
         let (wallet_desc, keymap) = desc
             .into_wallet_descriptor(&secp, Network::Testnet)
             .unwrap();
-        let signers_container = Arc::new(SignersContainer::from(keymap));
+        let signers_container = Arc::new(SignersContainer::build(keymap, &wallet_desc, &secp));
         let policy = wallet_desc
             .extract_policy(&signers_container, BuildSatisfaction::None, &secp)
             .unwrap()
@@ -1427,7 +1428,7 @@ mod test {
         let (wallet_desc, keymap) = desc
             .into_wallet_descriptor(&secp, Network::Testnet)
             .unwrap();
-        let signers_container = Arc::new(SignersContainer::from(keymap));
+        let signers_container = Arc::new(SignersContainer::build(keymap, &wallet_desc, &secp));
         let policy = wallet_desc
             .extract_policy(&signers_container, BuildSatisfaction::None, &secp)
             .unwrap()
@@ -1445,7 +1446,7 @@ mod test {
         let (wallet_desc, keymap) = desc
             .into_wallet_descriptor(&secp, Network::Testnet)
             .unwrap();
-        let signers_container = Arc::new(SignersContainer::from(keymap));
+        let signers_container = Arc::new(SignersContainer::build(keymap, &wallet_desc, &secp));
         let policy = wallet_desc
             .extract_policy(&signers_container, BuildSatisfaction::None, &secp)
             .unwrap()
@@ -1467,10 +1468,10 @@ mod test {
         let (wallet_desc, keymap) = desc
             .into_wallet_descriptor(&secp, Network::Testnet)
             .unwrap();
-        let signers = keymap.into();
+        let signers_container = Arc::new(SignersContainer::build(keymap, &wallet_desc, &secp));
 
         let policy = wallet_desc
-            .extract_policy(&signers, BuildSatisfaction::None, &secp)
+            .extract_policy(&signers_container, BuildSatisfaction::None, &secp)
             .unwrap()
             .unwrap();
 
@@ -1533,7 +1534,7 @@ mod test {
             addr.to_string()
         );
 
-        let signers_container = Arc::new(SignersContainer::from(keymap));
+        let signers_container = Arc::new(SignersContainer::build(keymap, &wallet_desc, &secp));
 
         let psbt = Psbt::from_str(ALICE_SIGNED_PSBT).unwrap();
 
@@ -1594,7 +1595,7 @@ mod test {
         let (wallet_desc, keymap) = desc
             .into_wallet_descriptor(&secp, Network::Testnet)
             .unwrap();
-        let signers_container = Arc::new(SignersContainer::from(keymap));
+        let signers_container = Arc::new(SignersContainer::build(keymap, &wallet_desc, &secp));
 
         let addr = wallet_desc
             .as_derived(0, &secp)
@@ -1682,7 +1683,7 @@ mod test {
         let (wallet_desc, keymap) = desc
             .into_wallet_descriptor(&secp, Network::Testnet)
             .unwrap();
-        let signers_container = Arc::new(SignersContainer::from(keymap));
+        let signers_container = Arc::new(SignersContainer::build(keymap, &wallet_desc, &secp));
 
         let policy = wallet_desc.extract_policy(&signers_container, BuildSatisfaction::None, &secp);
         assert!(policy.is_ok());

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -792,13 +792,18 @@ pub fn make_pkh<Pk: IntoDescriptorKey<Ctx>, Ctx: ScriptContext>(
 
 // Used internally by `bdk::fragment!` to build `multi()` fragments
 #[doc(hidden)]
-pub fn make_multi<Pk: IntoDescriptorKey<Ctx>, Ctx: ScriptContext>(
+pub fn make_multi<
+    Pk: IntoDescriptorKey<Ctx>,
+    Ctx: ScriptContext,
+    V: Fn(usize, Vec<DescriptorPublicKey>) -> Terminal<DescriptorPublicKey, Ctx>,
+>(
     thresh: usize,
+    variant: V,
     pks: Vec<Pk>,
     secp: &SecpCtx,
 ) -> Result<(Miniscript<DescriptorPublicKey, Ctx>, KeyMap, ValidNetworks), DescriptorError> {
     let (pks, key_map, valid_networks) = expand_multi_keys(pks, secp)?;
-    let minisc = Miniscript::from_ast(Terminal::Multi(thresh, pks))?;
+    let minisc = Miniscript::from_ast(variant(thresh, pks))?;
 
     minisc.check_miniscript()?;
 

--- a/src/testutils/blockchain_tests.rs
+++ b/src/testutils/blockchain_tests.rs
@@ -387,11 +387,25 @@ macro_rules! bdk_blockchain_tests {
                 Wallet::new(&descriptors.0.to_string(), descriptors.1.as_ref(), Network::Regtest, MemoryDatabase::new()).unwrap()
             }
 
-            fn init_single_sig() -> (Wallet<MemoryDatabase>, $blockchain, (String, Option<String>), TestClient) {
+            enum WalletType {
+                WpkhSingleSig,
+                TaprootKeySpend,
+                TaprootScriptSpend,
+            }
+
+            fn init_wallet(ty: WalletType) -> (Wallet<MemoryDatabase>, $blockchain, (String, Option<String>), TestClient) {
                 let _ = env_logger::try_init();
 
-                let descriptors = testutils! {
-                    @descriptors ( "wpkh(Alice)" ) ( "wpkh(Alice)" ) ( @keys ( "Alice" => (@generate_xprv "/44'/0'/0'/0/*", "/44'/0'/0'/1/*") ) )
+                let descriptors = match ty {
+                    WalletType::WpkhSingleSig => testutils! {
+                        @descriptors ( "wpkh(Alice)" ) ( "wpkh(Alice)" ) ( @keys ( "Alice" => (@generate_xprv "/44'/0'/0'/0/*", "/44'/0'/0'/1/*") ) )
+                    },
+                    WalletType::TaprootKeySpend => testutils! {
+                        @descriptors ( "tr(Alice)" ) ( "tr(Alice)" ) ( @keys ( "Alice" => (@generate_xprv "/44'/0'/0'/0/*", "/44'/0'/0'/1/*") ) )
+                    },
+                    WalletType::TaprootScriptSpend => testutils! {
+                        @descriptors ( "tr(Key,and_v(v:pk(Script),older(6)))" ) ( "tr(Key,and_v(v:pk(Script),older(6)))" ) ( @keys ( "Key" => (@literal "30e14486f993d5a2d222770e97286c56cec5af115e1fb2e0065f476a0fcf8788"), "Script" => (@generate_xprv "/0/*", "/1/*") ) )
+                    }
                 };
 
                 let test_client = TestClient::default();
@@ -403,6 +417,10 @@ macro_rules! bdk_blockchain_tests {
                 wallet.sync(&blockchain, SyncOptions::default()).unwrap();
 
                 (wallet, blockchain, descriptors, test_client)
+            }
+
+            fn init_single_sig() -> (Wallet<MemoryDatabase>, $blockchain, (String, Option<String>), TestClient) {
+                init_wallet(WalletType::WpkhSingleSig)
             }
 
             #[test]
@@ -1202,6 +1220,54 @@ macro_rules! bdk_blockchain_tests {
                 blockchain.broadcast(&tx).unwrap();
 
                 wallet.sync(&blockchain, SyncOptions::default()).unwrap();
+            }
+
+            #[test]
+            fn test_taproot_key_spend() {
+                let (wallet, blockchain, descriptors, mut test_client) = init_wallet(WalletType::TaprootKeySpend);
+
+                let _ = test_client.receive(testutils! {
+                    @tx ( (@external descriptors, 0) => 50_000 )
+                });
+                wallet.sync(&blockchain, SyncOptions::default()).unwrap();
+                assert_eq!(wallet.get_balance().unwrap(), 50_000);
+
+                let tx = {
+                    let mut builder = wallet.build_tx();
+                    builder.add_recipient(test_client.get_node_address(None).script_pubkey(), 25_000);
+                    let (mut psbt, _details) = builder.finish().unwrap();
+                    wallet.sign(&mut psbt, Default::default()).unwrap();
+                    psbt.extract_tx()
+                };
+                blockchain.broadcast(&tx).unwrap();
+            }
+
+            #[test]
+            fn test_taproot_script_spend() {
+                let (wallet, blockchain, descriptors, mut test_client) = init_wallet(WalletType::TaprootScriptSpend);
+
+                let _ = test_client.receive(testutils! {
+                    @tx ( (@external descriptors, 0) => 50_000 ) ( @confirmations 6 )
+                });
+                wallet.sync(&blockchain, SyncOptions::default()).unwrap();
+                assert_eq!(wallet.get_balance().unwrap(), 50_000);
+
+                let ext_policy = wallet.policies(KeychainKind::External).unwrap().unwrap();
+                let int_policy = wallet.policies(KeychainKind::Internal).unwrap().unwrap();
+
+                let ext_path = vec![(ext_policy.id.clone(), vec![1])].into_iter().collect();
+                let int_path = vec![(int_policy.id.clone(), vec![1])].into_iter().collect();
+
+                let tx = {
+                    let mut builder = wallet.build_tx();
+                    builder.add_recipient(test_client.get_node_address(None).script_pubkey(), 25_000)
+                        .policy_path(ext_path, KeychainKind::External)
+                        .policy_path(int_path, KeychainKind::Internal);
+                    let (mut psbt, _details) = builder.finish().unwrap();
+                    wallet.sign(&mut psbt, Default::default()).unwrap();
+                    psbt.extract_tx()
+                };
+                blockchain.broadcast(&tx).unwrap();
             }
         }
     };

--- a/src/testutils/blockchain_tests.rs
+++ b/src/testutils/blockchain_tests.rs
@@ -391,6 +391,8 @@ macro_rules! bdk_blockchain_tests {
                 WpkhSingleSig,
                 TaprootKeySpend,
                 TaprootScriptSpend,
+                TaprootScriptSpend2,
+                TaprootScriptSpend3,
             }
 
             fn init_wallet(ty: WalletType) -> (Wallet<MemoryDatabase>, $blockchain, (String, Option<String>), TestClient) {
@@ -405,7 +407,13 @@ macro_rules! bdk_blockchain_tests {
                     },
                     WalletType::TaprootScriptSpend => testutils! {
                         @descriptors ( "tr(Key,and_v(v:pk(Script),older(6)))" ) ( "tr(Key,and_v(v:pk(Script),older(6)))" ) ( @keys ( "Key" => (@literal "30e14486f993d5a2d222770e97286c56cec5af115e1fb2e0065f476a0fcf8788"), "Script" => (@generate_xprv "/0/*", "/1/*") ) )
-                    }
+                    },
+                    WalletType::TaprootScriptSpend2 => testutils! {
+                        @descriptors ( "tr(Alice,pk(Bob))" ) ( "tr(Alice,pk(Bob))" ) ( @keys ( "Alice" => (@literal "30e14486f993d5a2d222770e97286c56cec5af115e1fb2e0065f476a0fcf8788"), "Bob" => (@generate_xprv "/0/*", "/1/*") ) )
+                    },
+                    WalletType::TaprootScriptSpend3 => testutils! {
+                        @descriptors ( "tr(Alice,{pk(Bob),pk(Carol)})" ) ( "tr(Alice,{pk(Bob),pk(Carol)})" ) ( @keys ( "Alice" => (@literal "30e14486f993d5a2d222770e97286c56cec5af115e1fb2e0065f476a0fcf8788"), "Bob" => (@generate_xprv "/0/*", "/1/*"), "Carol" => (@generate_xprv "/0/*", "/1/*") ) )
+                    },
                 };
 
                 let test_client = TestClient::default();
@@ -1268,6 +1276,82 @@ macro_rules! bdk_blockchain_tests {
                     psbt.extract_tx()
                 };
                 blockchain.broadcast(&tx).unwrap();
+            }
+
+            #[test]
+            fn test_sign_taproot_core_keyspend_psbt() {
+                test_sign_taproot_core_psbt(WalletType::TaprootKeySpend);
+            }
+
+            #[test]
+            fn test_sign_taproot_core_scriptspend2_psbt() {
+                test_sign_taproot_core_psbt(WalletType::TaprootScriptSpend2);
+            }
+
+            #[test]
+            fn test_sign_taproot_core_scriptspend3_psbt() {
+                test_sign_taproot_core_psbt(WalletType::TaprootScriptSpend3);
+            }
+
+            fn test_sign_taproot_core_psbt(wallet_type: WalletType) {
+                use std::str::FromStr;
+                use serde_json;
+                use bitcoincore_rpc::jsonrpc::serde_json::Value;
+                use bitcoincore_rpc::{Auth, Client, RpcApi};
+
+                let (wallet, _blockchain, _descriptors, test_client) = init_wallet(wallet_type);
+
+                // TODO replace once rust-bitcoincore-rpc with PR 174 released
+                // https://github.com/rust-bitcoin/rust-bitcoincore-rpc/pull/174
+                let _createwallet_result: Value = test_client.bitcoind.client.call("createwallet", &["taproot_wallet".into(), true.into(), true.into(), serde_json::to_value("").unwrap(), false.into(), true.into(), true.into(), false.into()]).expect("created wallet");
+
+                let external_descriptor = wallet.get_descriptor_for_keychain(KeychainKind::External);
+
+                // TODO replace once bitcoind released with support for rust-bitcoincore-rpc PR 174
+                let taproot_wallet_client = Client::new(&test_client.bitcoind.rpc_url_with_wallet("taproot_wallet"), Auth::CookieFile(test_client.bitcoind.params.cookie_file.clone())).unwrap();
+
+                let descriptor_info = taproot_wallet_client.get_descriptor_info(external_descriptor.to_string().as_str()).expect("descriptor info");
+
+                let import_descriptor_args = json!([{
+                    "desc": descriptor_info.descriptor,
+                    "active": true,
+                    "timestamp": "now",
+                    "label":"taproot key spend",
+                }]);
+                let _importdescriptors_result: Value = taproot_wallet_client.call("importdescriptors", &[import_descriptor_args]).expect("import wallet");
+                let generate_to_address: bitcoin::Address = taproot_wallet_client.call("getnewaddress", &["test address".into(), "bech32m".into()]).expect("new address");
+                let _generatetoaddress_result = taproot_wallet_client.generate_to_address(101, &generate_to_address).expect("generated to address");
+                let send_to_address = wallet.get_address($crate::wallet::AddressIndex::New).unwrap().address.to_string();
+                let change_address = wallet.get_address($crate::wallet::AddressIndex::New).unwrap().address.to_string();
+                let send_addr_amounts = json!([{
+                    send_to_address: "0.4321"
+                }]);
+                let send_options = json!({
+                    "change_address": change_address,
+                    "psbt": true,
+                });
+                let send_result: Value = taproot_wallet_client.call("send", &[send_addr_amounts, Value::Null, "unset".into(), Value::Null, send_options]).expect("send psbt");
+                let core_psbt = send_result["psbt"].as_str().expect("core psbt str");
+
+                use bitcoin::util::psbt::PartiallySignedTransaction;
+
+                // Test parsing core created PSBT
+                let mut psbt = PartiallySignedTransaction::from_str(&core_psbt).expect("core taproot psbt");
+
+                // Test signing core created PSBT
+                let finalized = wallet.sign(&mut psbt, Default::default()).unwrap();
+                assert_eq!(finalized, true);
+
+                // Test with updated psbt
+                let update_result: Value = taproot_wallet_client.call("utxoupdatepsbt", &[core_psbt.into()]).expect("update psbt utxos");
+                let core_updated_psbt = update_result.as_str().expect("core updated psbt");
+
+                // Test parsing core created and updated PSBT
+                let mut psbt = PartiallySignedTransaction::from_str(&core_updated_psbt).expect("core taproot psbt");
+
+                // Test signing core created and updated PSBT
+                let finalized = wallet.sign(&mut psbt, Default::default()).unwrap();
+                assert_eq!(finalized, true);
             }
         }
     };

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -197,7 +197,7 @@ where
             KeychainKind::External,
             get_checksum(&descriptor.to_string())?.as_bytes(),
         )?;
-        let signers = Arc::new(SignersContainer::from(keymap));
+        let signers = Arc::new(SignersContainer::build(keymap, &descriptor, &secp));
         let (change_descriptor, change_signers) = match change_descriptor {
             Some(desc) => {
                 let (change_descriptor, change_keymap) =
@@ -207,7 +207,11 @@ where
                     get_checksum(&change_descriptor.to_string())?.as_bytes(),
                 )?;
 
-                let change_signers = Arc::new(SignersContainer::from(change_keymap));
+                let change_signers = Arc::new(SignersContainer::build(
+                    change_keymap,
+                    &change_descriptor,
+                    &secp,
+                ));
                 // if !parsed.same_structure(descriptor.as_ref()) {
                 //     return Err(Error::DifferentDescriptorStructure);
                 // }

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -4289,6 +4289,8 @@ pub(crate) mod test {
 
     #[test]
     fn test_taproot_psbt_input_tap_tree() {
+        use crate::bitcoin::psbt::serialize::Deserialize;
+        use crate::bitcoin::psbt::TapTree;
         use bitcoin::hashes::hex::FromHex;
         use bitcoin::util::taproot;
 
@@ -4327,6 +4329,11 @@ pub(crate) mod test {
         assert_eq!(
             psbt.inputs[0].tap_internal_key,
             psbt.outputs[0].tap_internal_key
+        );
+
+        assert_eq!(
+            psbt.outputs[0].tap_tree,
+            Some(TapTree::deserialize(&Vec::<u8>::from_hex("01c022208aee2b8120a5f157f1223f72b5e62b825831a27a9fdf427db7cc697494d4a642ac01c0222051494dc22e24a32fe9dcfbd7e85faf345fa1df296fb49d156e859ef345201295ac",).unwrap()).unwrap())
         );
     }
 

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -4223,7 +4223,7 @@ pub(crate) mod test {
         let (wallet, _, _) = get_funded_wallet(get_test_tr_repeated_key());
         let addr = wallet.get_address(AddressIndex::New).unwrap();
 
-        let path = vec![("u6ugnnck".to_string(), vec![0])]
+        let path = vec![("rn4nre9c".to_string(), vec![0])]
             .into_iter()
             .collect();
 

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -302,8 +302,7 @@ impl InputSigner for SignerWrapper<DescriptorXKey<ExtendedPrivKey>> {
         let tap_key_origins = psbt.inputs[input_index]
             .tap_key_origins
             .iter()
-            .map(|(pk, (_, keysource))| (SinglePubKey::XOnly(*pk), keysource))
-            .collect::<Vec<_>>();
+            .map(|(pk, (_, keysource))| (SinglePubKey::XOnly(*pk), keysource));
         let (public_key, full_path) = match psbt.inputs[input_index]
             .bip32_derivation
             .iter()

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -26,7 +26,7 @@
 //! # #[derive(Debug)]
 //! # struct CustomHSM;
 //! # impl CustomHSM {
-//! #     fn sign_input(&self, _psbt: &mut psbt::PartiallySignedTransaction, _input: usize) -> Result<(), SignerError> {
+//! #     fn hsm_sign_input(&self, _psbt: &mut psbt::PartiallySignedTransaction, _input: usize) -> Result<(), SignerError> {
 //! #         Ok(())
 //! #     }
 //! #     fn connect() -> Self {
@@ -47,25 +47,22 @@
 //!     }
 //! }
 //!
-//! impl Signer for CustomSigner {
-//!     fn sign(
-//!         &self,
-//!         psbt: &mut psbt::PartiallySignedTransaction,
-//!         input_index: Option<usize>,
-//!         _secp: &Secp256k1<All>,
-//!     ) -> Result<(), SignerError> {
-//!         let input_index = input_index.ok_or(SignerError::InputIndexOutOfRange)?;
-//!         self.device.sign_input(psbt, input_index)?;
-//!
-//!         Ok(())
-//!     }
-//!
+//! impl SignerCommon for CustomSigner {
 //!     fn id(&self, _secp: &Secp256k1<All>) -> SignerId {
 //!         self.device.get_id()
 //!     }
+//! }
 //!
-//!     fn sign_whole_tx(&self) -> bool {
-//!         false
+//! impl InputSigner for CustomSigner {
+//!     fn sign_input(
+//!         &self,
+//!         psbt: &mut psbt::PartiallySignedTransaction,
+//!         input_index: usize,
+//!         _secp: &Secp256k1<All>,
+//!     ) -> Result<(), SignerError> {
+//!         self.device.hsm_sign_input(psbt, input_index)?;
+//!
+//!         Ok(())
 //!     }
 //! }
 //!
@@ -91,14 +88,14 @@ use std::sync::Arc;
 use bitcoin::blockdata::opcodes;
 use bitcoin::blockdata::script::Builder as ScriptBuilder;
 use bitcoin::hashes::{hash160, Hash};
-use bitcoin::secp256k1;
 use bitcoin::secp256k1::{Message, Secp256k1};
 use bitcoin::util::bip32::{ChildNumber, DerivationPath, ExtendedPrivKey, Fingerprint};
-use bitcoin::util::{ecdsa, psbt, sighash};
-use bitcoin::{EcdsaSighashType, PrivateKey, PublicKey, Script, Sighash};
+use bitcoin::util::{ecdsa, psbt, schnorr, sighash, taproot};
+use bitcoin::{secp256k1, XOnlyPublicKey};
+use bitcoin::{EcdsaSighashType, PrivateKey, PublicKey, SchnorrSighashType, Script};
 
 use miniscript::descriptor::{DescriptorSecretKey, DescriptorSinglePriv, DescriptorXKey, KeyMap};
-use miniscript::{Legacy, MiniscriptKey, Segwitv0};
+use miniscript::{Legacy, MiniscriptKey, Segwitv0, Tap};
 
 use super::utils::SecpCtx;
 use crate::descriptor::XKeyUtils;
@@ -174,27 +171,8 @@ impl fmt::Display for SignerError {
 
 impl std::error::Error for SignerError {}
 
-/// Trait for signers
-///
-/// This trait can be implemented to provide customized signers to the wallet. For an example see
-/// [`this module`](crate::wallet::signer)'s documentation.
-pub trait Signer: fmt::Debug + Send + Sync {
-    /// Sign a PSBT
-    ///
-    /// The `input_index` argument is only provided if the wallet doesn't declare to sign the whole
-    /// transaction in one go (see [`Signer::sign_whole_tx`]). Otherwise its value is `None` and
-    /// can be ignored.
-    fn sign(
-        &self,
-        psbt: &mut psbt::PartiallySignedTransaction,
-        input_index: Option<usize>,
-        secp: &SecpCtx,
-    ) -> Result<(), SignerError>;
-
-    /// Return whether or not the signer signs the whole transaction in one go instead of every
-    /// input individually
-    fn sign_whole_tx(&self) -> bool;
-
+/// Common signer methods
+pub trait SignerCommon: fmt::Debug + Send + Sync {
     /// Return the [`SignerId`] for this signer
     ///
     /// The [`SignerId`] can be used to lookup a signer in the [`Wallet`](crate::Wallet)'s signers map or to
@@ -211,14 +189,65 @@ pub trait Signer: fmt::Debug + Send + Sync {
     }
 }
 
-impl Signer for DescriptorXKey<ExtendedPrivKey> {
-    fn sign(
+/// PSBT Input signer
+///
+/// This trait can be implemented to provide custom signers to the wallet. If the signer supports signing
+/// individual inputs, this trait should be implemented and BDK will provide automatically an implementation
+/// for [`TransactionSigner`].
+pub trait InputSigner: SignerCommon {
+    /// Sign a single psbt input
+    fn sign_input(
         &self,
         psbt: &mut psbt::PartiallySignedTransaction,
-        input_index: Option<usize>,
+        input_index: usize,
+        secp: &SecpCtx,
+    ) -> Result<(), SignerError>;
+}
+
+/// PSBT signer
+///
+/// This trait can be implemented when the signer can't sign inputs individually, but signs the whole transaction
+/// at once.
+pub trait TransactionSigner: SignerCommon {
+    /// Sign all the inputs of the psbt
+    fn sign_transaction(
+        &self,
+        psbt: &mut psbt::PartiallySignedTransaction,
+        secp: &SecpCtx,
+    ) -> Result<(), SignerError>;
+}
+
+impl<T: InputSigner> TransactionSigner for T {
+    fn sign_transaction(
+        &self,
+        psbt: &mut psbt::PartiallySignedTransaction,
         secp: &SecpCtx,
     ) -> Result<(), SignerError> {
-        let input_index = input_index.unwrap();
+        for input_index in 0..psbt.inputs.len() {
+            self.sign_input(psbt, input_index, secp)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl SignerCommon for DescriptorXKey<ExtendedPrivKey> {
+    fn id(&self, secp: &SecpCtx) -> SignerId {
+        SignerId::from(self.root_fingerprint(secp))
+    }
+
+    fn descriptor_secret_key(&self) -> Option<DescriptorSecretKey> {
+        Some(DescriptorSecretKey::XPrv(self.clone()))
+    }
+}
+
+impl InputSigner for DescriptorXKey<ExtendedPrivKey> {
+    fn sign_input(
+        &self,
+        psbt: &mut psbt::PartiallySignedTransaction,
+        input_index: usize,
+        secp: &SecpCtx,
+    ) -> Result<(), SignerError> {
         if input_index >= psbt.inputs.len() {
             return Err(SignerError::InputIndexOutOfRange);
         }
@@ -265,31 +294,31 @@ impl Signer for DescriptorXKey<ExtendedPrivKey> {
                 network: self.xkey.network,
                 inner: derived_key.private_key,
             }
-            .sign(psbt, Some(input_index), secp)
+            .sign_input(psbt, input_index, secp)
         }
-    }
-
-    fn sign_whole_tx(&self) -> bool {
-        false
-    }
-
-    fn id(&self, secp: &SecpCtx) -> SignerId {
-        SignerId::from(self.root_fingerprint(secp))
-    }
-
-    fn descriptor_secret_key(&self) -> Option<DescriptorSecretKey> {
-        Some(DescriptorSecretKey::XPrv(self.clone()))
     }
 }
 
-impl Signer for PrivateKey {
-    fn sign(
+impl SignerCommon for PrivateKey {
+    fn id(&self, secp: &SecpCtx) -> SignerId {
+        SignerId::from(self.public_key(secp).to_pubkeyhash())
+    }
+
+    fn descriptor_secret_key(&self) -> Option<DescriptorSecretKey> {
+        Some(DescriptorSecretKey::SinglePriv(DescriptorSinglePriv {
+            key: *self,
+            origin: None,
+        }))
+    }
+}
+
+impl InputSigner for PrivateKey {
+    fn sign_input(
         &self,
         psbt: &mut psbt::PartiallySignedTransaction,
-        input_index: Option<usize>,
+        input_index: usize,
         secp: &SecpCtx,
     ) -> Result<(), SignerError> {
-        let input_index = input_index.unwrap();
         if input_index >= psbt.inputs.len() || input_index >= psbt.unsigned_tx.input.len() {
             return Err(SignerError::InputIndexOutOfRange);
         }
@@ -301,48 +330,127 @@ impl Signer for PrivateKey {
         }
 
         let pubkey = PublicKey::from_private_key(secp, self);
-        if psbt.inputs[input_index].partial_sigs.contains_key(&pubkey) {
-            return Ok(());
+        let x_only_pubkey = XOnlyPublicKey::from(pubkey.inner);
+        let is_taproot = psbt.inputs[input_index].tap_internal_key.is_some()
+            || psbt.inputs[input_index].tap_merkle_root.is_some();
+
+        match psbt.inputs[input_index].tap_internal_key {
+            Some(k) if k == x_only_pubkey && psbt.inputs[input_index].tap_key_sig.is_none() => {
+                let (hash, hash_ty) = Tap::sighash(psbt, input_index, None)?;
+                sign_psbt_schnorr(
+                    &self.inner,
+                    x_only_pubkey,
+                    None,
+                    &mut psbt.inputs[input_index],
+                    hash,
+                    hash_ty,
+                    secp,
+                );
+            }
+            _ => {}
+        }
+        if let Some((leaf_hashes, _)) = psbt.inputs[input_index].tap_key_origins.get(&x_only_pubkey)
+        {
+            let leaf_hashes = leaf_hashes
+                .iter()
+                .filter(|lh| {
+                    !psbt.inputs[input_index]
+                        .tap_script_sigs
+                        .contains_key(&(x_only_pubkey, **lh))
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            for lh in leaf_hashes {
+                let (hash, hash_ty) = Tap::sighash(psbt, input_index, Some(lh))?;
+                sign_psbt_schnorr(
+                    &self.inner,
+                    x_only_pubkey,
+                    Some(lh),
+                    &mut psbt.inputs[input_index],
+                    hash,
+                    hash_ty,
+                    secp,
+                );
+            }
         }
 
-        // FIXME: use the presence of `witness_utxo` as an indication that we should make a bip143
-        // sig. Does this make sense? Should we add an extra argument to explicitly switch between
-        // these? The original idea was to declare sign() as sign<Ctx: ScriptContex>() and use Ctx,
-        // but that violates the rules for trait-objects, so we can't do it.
-        let (hash, sighash) = match psbt.inputs[input_index].witness_utxo {
-            Some(_) => Segwitv0::sighash(psbt, input_index)?,
-            None => Legacy::sighash(psbt, input_index)?,
-        };
+        if !is_taproot {
+            if psbt.inputs[input_index].partial_sigs.contains_key(&pubkey) {
+                return Ok(());
+            }
 
-        let sig = secp.sign_ecdsa(
-            &Message::from_slice(&hash.into_inner()[..]).unwrap(),
-            &self.inner,
-        );
-
-        let final_signature = ecdsa::EcdsaSig {
-            sig,
-            hash_ty: sighash.ecdsa_hash_ty().unwrap(), // FIXME
-        };
-        psbt.inputs[input_index]
-            .partial_sigs
-            .insert(pubkey, final_signature);
+            // FIXME: use the presence of `witness_utxo` as an indication that we should make a bip143
+            // sig. Does this make sense? Should we add an extra argument to explicitly switch between
+            // these? The original idea was to declare sign() as sign<Ctx: ScriptContex>() and use Ctx,
+            // but that violates the rules for trait-objects, so we can't do it.
+            let (hash, hash_ty) = match psbt.inputs[input_index].witness_utxo {
+                Some(_) => Segwitv0::sighash(psbt, input_index, ())?,
+                None => Legacy::sighash(psbt, input_index, ())?,
+            };
+            sign_psbt_ecdsa(
+                &self.inner,
+                pubkey,
+                &mut psbt.inputs[input_index],
+                hash,
+                hash_ty,
+                secp,
+            );
+        }
 
         Ok(())
     }
+}
 
-    fn sign_whole_tx(&self) -> bool {
-        false
-    }
+fn sign_psbt_ecdsa(
+    secret_key: &secp256k1::SecretKey,
+    pubkey: PublicKey,
+    psbt_input: &mut psbt::Input,
+    hash: bitcoin::Sighash,
+    hash_ty: EcdsaSighashType,
+    secp: &SecpCtx,
+) {
+    let sig = secp.sign_ecdsa(
+        &Message::from_slice(&hash.into_inner()[..]).unwrap(),
+        secret_key,
+    );
 
-    fn id(&self, secp: &SecpCtx) -> SignerId {
-        SignerId::from(self.public_key(secp).to_pubkeyhash())
-    }
+    let final_signature = ecdsa::EcdsaSig { sig, hash_ty };
+    psbt_input.partial_sigs.insert(pubkey, final_signature);
+}
 
-    fn descriptor_secret_key(&self) -> Option<DescriptorSecretKey> {
-        Some(DescriptorSecretKey::SinglePriv(DescriptorSinglePriv {
-            key: *self,
-            origin: None,
-        }))
+// Calling this with `leaf_hash` = `None` will sign for key-spend
+fn sign_psbt_schnorr(
+    secret_key: &secp256k1::SecretKey,
+    pubkey: XOnlyPublicKey,
+    leaf_hash: Option<taproot::TapLeafHash>,
+    psbt_input: &mut psbt::Input,
+    hash: taproot::TapSighashHash,
+    hash_ty: SchnorrSighashType,
+    secp: &SecpCtx,
+) {
+    use schnorr::TapTweak;
+
+    let keypair = secp256k1::KeyPair::from_seckey_slice(secp, secret_key.as_ref()).unwrap();
+    let keypair = match leaf_hash {
+        None => keypair
+            .tap_tweak(secp, psbt_input.tap_merkle_root)
+            .into_inner(),
+        Some(_) => keypair, // no tweak for script spend
+    };
+
+    let sig = secp.sign_schnorr(
+        &Message::from_slice(&hash.into_inner()[..]).unwrap(),
+        &keypair,
+    );
+
+    let final_signature = schnorr::SchnorrSig { sig, hash_ty };
+
+    if let Some(lh) = leaf_hash {
+        psbt_input
+            .tap_script_sigs
+            .insert((pubkey, lh), final_signature);
+    } else {
+        psbt_input.tap_key_sig = Some(final_signature)
     }
 }
 
@@ -377,7 +485,7 @@ impl From<(SignerId, SignerOrdering)> for SignersContainerKey {
 
 /// Container for multiple signers
 #[derive(Debug, Default, Clone)]
-pub struct SignersContainer(BTreeMap<SignersContainerKey, Arc<dyn Signer>>);
+pub struct SignersContainer(BTreeMap<SignersContainerKey, Arc<dyn TransactionSigner>>);
 
 impl SignersContainer {
     /// Create a map of public keys to secret keys
@@ -426,13 +534,17 @@ impl SignersContainer {
         &mut self,
         id: SignerId,
         ordering: SignerOrdering,
-        signer: Arc<dyn Signer>,
-    ) -> Option<Arc<dyn Signer>> {
+        signer: Arc<dyn TransactionSigner>,
+    ) -> Option<Arc<dyn TransactionSigner>> {
         self.0.insert((id, ordering).into(), signer)
     }
 
     /// Removes a signer from the container and returns it
-    pub fn remove(&mut self, id: SignerId, ordering: SignerOrdering) -> Option<Arc<dyn Signer>> {
+    pub fn remove(
+        &mut self,
+        id: SignerId,
+        ordering: SignerOrdering,
+    ) -> Option<Arc<dyn TransactionSigner>> {
         self.0.remove(&(id, ordering).into())
     }
 
@@ -445,12 +557,12 @@ impl SignersContainer {
     }
 
     /// Returns the list of signers in the container, sorted by lowest to highest `ordering`
-    pub fn signers(&self) -> Vec<&Arc<dyn Signer>> {
+    pub fn signers(&self) -> Vec<&Arc<dyn TransactionSigner>> {
         self.0.values().collect()
     }
 
     /// Finds the signer with lowest ordering for a given id in the container.
-    pub fn find(&self, id: SignerId) -> Option<&Arc<dyn Signer>> {
+    pub fn find(&self, id: SignerId) -> Option<&Arc<dyn TransactionSigner>> {
         self.0
             .range((
                 Included(&(id.clone(), SignerOrdering(0)).into()),
@@ -508,17 +620,27 @@ impl Default for SignOptions {
 }
 
 pub(crate) trait ComputeSighash {
+    type Extra;
+    type Sighash;
+    type SighashType;
+
     fn sighash(
         psbt: &psbt::PartiallySignedTransaction,
         input_index: usize,
-    ) -> Result<(Sighash, psbt::PsbtSighashType), SignerError>;
+        extra: Self::Extra,
+    ) -> Result<(Self::Sighash, Self::SighashType), SignerError>;
 }
 
 impl ComputeSighash for Legacy {
+    type Extra = ();
+    type Sighash = bitcoin::Sighash;
+    type SighashType = EcdsaSighashType;
+
     fn sighash(
         psbt: &psbt::PartiallySignedTransaction,
         input_index: usize,
-    ) -> Result<(Sighash, psbt::PsbtSighashType), SignerError> {
+        _extra: (),
+    ) -> Result<(Self::Sighash, Self::SighashType), SignerError> {
         if input_index >= psbt.inputs.len() || input_index >= psbt.unsigned_tx.input.len() {
             return Err(SignerError::InputIndexOutOfRange);
         }
@@ -528,7 +650,9 @@ impl ComputeSighash for Legacy {
 
         let sighash = psbt_input
             .sighash_type
-            .unwrap_or_else(|| EcdsaSighashType::All.into());
+            .unwrap_or_else(|| EcdsaSighashType::All.into())
+            .ecdsa_hash_ty()
+            .map_err(|_| SignerError::InvalidSighash)?;
         let script = match psbt_input.redeem_script {
             Some(ref redeem_script) => redeem_script.clone(),
             None => {
@@ -567,10 +691,15 @@ fn p2wpkh_script_code(script: &Script) -> Script {
 }
 
 impl ComputeSighash for Segwitv0 {
+    type Extra = ();
+    type Sighash = bitcoin::Sighash;
+    type SighashType = EcdsaSighashType;
+
     fn sighash(
         psbt: &psbt::PartiallySignedTransaction,
         input_index: usize,
-    ) -> Result<(Sighash, psbt::PsbtSighashType), SignerError> {
+        _extra: (),
+    ) -> Result<(Self::Sighash, Self::SighashType), SignerError> {
         if input_index >= psbt.inputs.len() || input_index >= psbt.unsigned_tx.input.len() {
             return Err(SignerError::InputIndexOutOfRange);
         }
@@ -631,7 +760,62 @@ impl ComputeSighash for Segwitv0 {
                 value,
                 sighash,
             )?,
-            sighash.into(),
+            sighash,
+        ))
+    }
+}
+
+impl ComputeSighash for Tap {
+    type Extra = Option<taproot::TapLeafHash>;
+    type Sighash = taproot::TapSighashHash;
+    type SighashType = SchnorrSighashType;
+
+    fn sighash(
+        psbt: &psbt::PartiallySignedTransaction,
+        input_index: usize,
+        extra: Self::Extra,
+    ) -> Result<(Self::Sighash, SchnorrSighashType), SignerError> {
+        if input_index >= psbt.inputs.len() || input_index >= psbt.unsigned_tx.input.len() {
+            return Err(SignerError::InputIndexOutOfRange);
+        }
+
+        let psbt_input = &psbt.inputs[input_index];
+
+        let sighash_type = psbt_input
+            .sighash_type
+            .unwrap_or_else(|| SchnorrSighashType::Default.into())
+            .schnorr_hash_ty()
+            .map_err(|_| SignerError::InvalidSighash)?;
+        let witness_utxos = psbt
+            .inputs
+            .iter()
+            .cloned()
+            .map(|i| i.witness_utxo)
+            .collect::<Vec<_>>();
+        let mut all_witness_utxos = vec![];
+
+        let mut cache = sighash::SighashCache::new(&psbt.unsigned_tx);
+        let is_anyone_can_pay = psbt::PsbtSighashType::from(sighash_type).to_u32() & 0x80 != 0;
+        let prevouts = if is_anyone_can_pay {
+            sighash::Prevouts::One(
+                input_index,
+                witness_utxos[input_index]
+                    .as_ref()
+                    .ok_or(SignerError::MissingWitnessUtxo)?,
+            )
+        } else if witness_utxos.iter().all(Option::is_some) {
+            all_witness_utxos.extend(witness_utxos.iter().filter_map(|x| x.as_ref()));
+            sighash::Prevouts::All(&all_witness_utxos)
+        } else {
+            return Err(SignerError::MissingWitnessUtxo);
+        };
+
+        // Assume no OP_CODESEPARATOR
+        let extra = extra.map(|leaf_hash| (leaf_hash, 0xFFFFFFFF));
+
+        Ok((
+            cache.taproot_signature_hash(input_index, &prevouts, None, extra, sighash_type)?,
+            sighash_type,
         ))
     }
 }
@@ -666,12 +850,11 @@ mod signers_container_tests {
     use crate::keys::{DescriptorKey, IntoDescriptorKey};
     use bitcoin::secp256k1::{All, Secp256k1};
     use bitcoin::util::bip32;
-    use bitcoin::util::psbt::PartiallySignedTransaction;
     use bitcoin::Network;
     use miniscript::ScriptContext;
     use std::str::FromStr;
 
-    fn is_equal(this: &Arc<dyn Signer>, that: &Arc<DummySigner>) -> bool {
+    fn is_equal(this: &Arc<dyn TransactionSigner>, that: &Arc<DummySigner>) -> bool {
         let secp = Secp256k1::new();
         this.id(&secp) == that.id(&secp)
     }
@@ -752,22 +935,19 @@ mod signers_container_tests {
         number: u64,
     }
 
-    impl Signer for DummySigner {
-        fn sign(
-            &self,
-            _psbt: &mut PartiallySignedTransaction,
-            _input_index: Option<usize>,
-            _secp: &SecpCtx,
-        ) -> Result<(), SignerError> {
-            Ok(())
-        }
-
+    impl SignerCommon for DummySigner {
         fn id(&self, _secp: &SecpCtx) -> SignerId {
             SignerId::Dummy(self.number)
         }
+    }
 
-        fn sign_whole_tx(&self) -> bool {
-            true
+    impl TransactionSigner for DummySigner {
+        fn sign_transaction(
+            &self,
+            _psbt: &mut psbt::PartiallySignedTransaction,
+            _secp: &SecpCtx,
+        ) -> Result<(), SignerError> {
+            Ok(())
         }
     }
 

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -334,8 +334,9 @@ impl<'a, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderContext>
     /// 1. The `psbt_input` does not contain a `witness_utxo` or `non_witness_utxo`.
     /// 2. The data in `non_witness_utxo` does not match what is in `outpoint`.
     ///
-    /// Note unless you set [`only_witness_utxo`] any `psbt_input` you pass to this method must
-    /// have `non_witness_utxo` set otherwise you will get an error when [`finish`] is called.
+    /// Note unless you set [`only_witness_utxo`] any non-taproot `psbt_input` you pass to this
+    /// method must have `non_witness_utxo` set otherwise you will get an error when [`finish`]
+    /// is called.
     ///
     /// [`only_witness_utxo`]: Self::only_witness_utxo
     /// [`finish`]: Self::finish


### PR DESCRIPTION
The author **afilini** wrote the following PR called **Add support for Taproot and `tr()` descriptors**, issue number **593** in **bitcoindevkit/bdk** cloned by FreshEyes below:

### Description

This is a work-in-progress PR to update BDK to rust-bitcoin `0.28` which introduces taproot support and a few other improvements. While updating we also introduce taproot support in BDK.

High level list of subtasks for this PR:
- [x] Update rust-bitcoin and rust-miniscript
- [x] Stop using deprecated structs
- [x] Add taproot metadata to psbts
- [x] Produce schnorr signatures
- [x] Finalize taproot txs
- [x] Support `tr()` descriptors in the `descriptor!()` macro
- [x] Write a lot of tests
  - [x] Interoperability with other wallets (Core + ?)
     - [x] Signing/finalizing a psbt made by core
     - [x] Producing a psbt that core can sign and finalize
  - [x] Creating psbts
    - [x] Verify the metadata are correct
    - [x] Verify sighashes are applied correctly
    - [x] Create a tx with a foreign taproot and non-taproot utxo
  - [x] Signing psbts
    - [x] Signing for a key spend
    - [x] Signing for a script spend
    - [x] Signing with a single (wif) key
    - [x] Signing with an xprv (with and without knowing the utxo being spent in the db)
    - [x] Signing with weird sighashes
  - [x] Policy module
    - [x] Simple key spend
    - [x] More complex tap tree with a few keys
    - [x] Verify both `contribution` and `satisfaction` of a PSBT input
  - [x] Wallet module
    - [x] Generate addresses

Fixes `#63` 

### Notes to the reviewers

#### Milestone

I'm adding this to the `0.19` milestone because now that rust-bitcoin and rust-miniscript have been released we should not waiting too long to release a version of BDK that supports the new libraries.

#### API Breaks

Since this is an API-break because of the new version of rust-bitcoin and rust-miniscript, I'm also taking the chance to update a few things in our lib that I had been thinking about for a while.

One example is the signer interface, which had that weird `sign_whole_tx()` method. This has now been removed, and the `Signer` trait replaced with `TransactionSigner` and `0.28`0. I'm also starting to think that the signer should not only look at the psbt to figure out what to do, but ideally it should also receive some information about the descriptor (for example, the type) to simplify the code.

One option is to add an extra parameter, but that would probably only be used by our internal signers and not much else (for example, if you ask an hardware wallet to sign, it will probably already know what kind of wallet you have).

Another option is to wrap `0.28`1 and `0.28`2 which are the two internal signers we support with a struct that contains metadata about the descriptor, and then implement the signer traits on that struct. We could construct this in `0.28`3, after miniscript parses the descriptor.

#### MSRV Bump

Due to the update of `0.28`4, which in turn depends on an updated `0.28`5, we will have to bump our MSRV beacuse 1.46 is not supported by the new `0.28`6 version.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](`https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md`)
* [x] I ran `0.28`7 and `0.28`8 before committing

#### New Features:

* [x] I've added docs for the new feature
* [ ] I've updated `0.28`9
